### PR TITLE
Expand feature write fasta from genomes

### DIFF
--- a/pyrewton/parsers/parser_get_genbank_annotations.py
+++ b/pyrewton/parsers/parser_get_genbank_annotations.py
@@ -33,16 +33,14 @@ def build_parser(argv: Optional[List] = None):
         description="Retrieve protein annotations from GenBank files",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-
     # Add arguments to parser
-    # Add option to specific input directory for dataframe
     parser.add_argument(
         "-d",
-        "--df_input",
+        "--output_df",
         type=Path,
-        metavar="input dataframe name",
-        default=sys.stdin,
-        help="input dataframe path",
+        metavar="Output dataframe path",
+        default=sys.stdout,
+        help="Path to output dataframe",
     )
     # Add option to force file over writting
     parser.add_argument(
@@ -61,6 +59,15 @@ def build_parser(argv: Optional[List] = None):
         metavar="GenBank file directory",
         default=sys.stdin,
         help="GenBank file path directory",
+    )
+    # Add option to specific input directory for dataframe
+    parser.add_argument(
+        "-i",
+        "--input_df",
+        type=Path,
+        metavar="input dataframe name",
+        default=sys.stdin,
+        help="input dataframe path",
     )
     # Add option to specific directory for log to be written out to
     parser.add_argument(
@@ -86,9 +93,9 @@ def build_parser(argv: Optional[List] = None):
         "-o",
         "--output",
         type=Path,
-        metavar="output directory",
+        metavar="output directory for fasta files",
         default=sys.stdout,
-        help="Path to directory where all outputs are written",
+        help="Path to directory fasta files are written",
     )
     # Add option to specify verbose logging
     parser.add_argument(

--- a/pyrewton/parsers/parser_get_genbank_annotations.py
+++ b/pyrewton/parsers/parser_get_genbank_annotations.py
@@ -86,9 +86,9 @@ def build_parser(argv: Optional[List] = None):
         "-o",
         "--output",
         type=Path,
-        metavar="output file name",
+        metavar="output directory",
         default=sys.stdout,
-        help="output filename",
+        help="Path to directory where all outputs are written",
     )
     # Add option to specify verbose logging
     parser.add_argument(

--- a/tests/test_genbank_gt_gnbnk_anntns.py
+++ b/tests/test_genbank_gt_gnbnk_anntns.py
@@ -114,15 +114,59 @@ def no_gb_args(test_dir, gb_file_dir):
 
 @pytest.fixture
 def output_dir(test_dir):
-    path = test_dir / "test_targets" / "gt_unprt_prtns_test_targets"
+    path = test_dir / "test_targets" / "gt_gnbnk_anntns_test_targets"
     return path
+
+
+@pytest.fixture
+def args_fasta(output_dir):
+    argsdict = {"args": Namespace(fasta=True, output=output_dir)}
+    return argsdict
+
+
+@pytest.fixture
+def protein_df():
+    columns_list = [
+        "Genus",
+        "Species",
+        "NCBI Taxonomy ID",
+        "NCBI Accession Number",
+        "NCBI Protein ID",
+        "Locus Tag",
+        "Gene Locus",
+        "Function",
+        "Protein Sequence",
+    ]
+    data = [
+        [
+            "Botrytis",
+            "cinerea B05.10",
+            "NCBI:txid332648",
+            "GCF_000143535.2",
+            "XP_001553137.1",
+            "BCIN_14g02180",
+            "[891975:892232](-),[891495:891895](-)",
+            "hypothetical proteins",
+            "MSSHCHDEHDHGHGGHSHEGHDHSDDITPALQYSLYQHIKFDDITT",
+        ]
+    ]
+    df = pd.DataFrame(data, columns=columns_list)
+    return df
+
+
+@pytest.fixture
+def df_series(protein_df):
+    df_row = protein_df.iloc[0]
+    return df_row
 
 
 # Test coordination of script
 
 
 @pytest.mark.run(order=36)
-def test_main(null_logger, output_dir, coordination_args, test_input_df, monkeypatch):
+def test_main(
+    null_logger, output_dir, coordination_args, test_input_df, protein_df, monkeypatch
+):
     """Test coordination of GenBank protein annotation retrieval by main()."""
 
     def mock_built_parser(*args, **kwargs):
@@ -138,9 +182,11 @@ def test_main(null_logger, output_dir, coordination_args, test_input_df, monkeyp
     def mock_parser(*args, **kwargs):
         parser = Namespace(
             output=output_dir,
-            force=False,
+            force=True,
             genbank=gb_file_dir,
-            df_input=test_input_df_path,
+            input_df=test_input_df_path,
+            nodelete=True,
+            output_df=output_dir,
         )
         return parser
 
@@ -151,7 +197,7 @@ def test_main(null_logger, output_dir, coordination_args, test_input_df, monkeyp
         return test_input_df_path
 
     def mock_create_dataframe(*args, **kwargs):
-        df = test_input_df
+        df = protein_df
         return df
 
     def mock_write_out_dataframe(*args, **kwargs):
@@ -399,3 +445,8 @@ def test_get_file_empty(coordination_args, null_logger):
         accession, coordination_args["args"], null_logger
     )
 
+
+@pytest.mark.run(order=51)
+def test_write_proteins_to_fasta(df_series, null_logger, args_fasta):
+    """Test writing fasta file."""
+    get_genbank_annotations.write_fasta(df_series, null_logger, args_fasta["args"])


### PR DESCRIPTION
Added feature to get_genbank_annotations.py to write out protein sequences to a FASTA file per genomic assembly (identified by accession number).